### PR TITLE
videoProperties isn't always defined

### DIFF
--- a/tv_grab_sd_json
+++ b/tv_grab_sd_json
@@ -1299,6 +1299,10 @@ sub get_program_video {
 	my ($program) = @_;
 	my %video;
 
+	if (! $program->{'videoProperties'}) {
+	    return undef;
+	}
+
 	for my $item (@{$program->{'videoProperties'}}) {
 		if($item =~ /hdtv/i) {
 			$video{'quality'} = 'HDTV';

--- a/tv_grab_sd_json
+++ b/tv_grab_sd_json
@@ -1297,13 +1297,19 @@ sub get_program_episode {
 
 sub get_program_video {
 	my ($program) = @_;
-	my %video;
+	my(@items, %video);
 
 	if (! $program->{'videoProperties'}) {
 	    return undef;
 	}
-
-	for my $item (@{$program->{'videoProperties'}}) {
+        elsif (ref $program->{'videoProperties'} eq 'HASH') {
+            @items = values %{$program->{'videoProperties'}};
+        }
+        else {
+            @items = @{$program->{'videoProperties'}};
+        }
+         
+	for my $item (@items) {
 		if($item =~ /hdtv/i) {
 			$video{'quality'} = 'HDTV';
 		}


### PR DESCRIPTION
I just started getting:

Not an ARRAY reference at /usr/bin/tv_grab_sd_json line 1302

Apparently `videoProperties` is no longer being defined on every program.

This patch fixes the issue.
